### PR TITLE
Bump commons-beanutils from 1.9.3 to 1.9.4 in /smart-admin-service

### DIFF
--- a/smart-admin-service/pom.xml
+++ b/smart-admin-service/pom.xml
@@ -33,7 +33,7 @@
         <easypoi.version>4.1.2</easypoi.version>
         <commons-fileupload.version>1.3.1</commons-fileupload.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>
-        <commons-beanutils.version>1.9.3</commons-beanutils.version>
+        <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-pool2.version>2.8.0</commons-pool2.version>
         <kaptcha.version>2.3.2</kaptcha.version>
         <okhttp.version>4.2.2</okhttp.version>


### PR DESCRIPTION
Bumps commons-beanutils from 1.9.3 to 1.9.4.

Signed-off-by: dependabot[bot] <support@github.com>